### PR TITLE
Add Fedora 29 distro

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,4 @@ freeipaclient_supported_distributions:
   - CentOS-7
   - Fedora-24
   - Fedora-27
+  - Fedora-29


### PR DESCRIPTION
Upgraded to Fedora 29 in our lab.  Which lead to this issue. 

TASK [CTL-Fed-Security.freeipa-client : Assert supported distribution] **************************************************************************************
task path: /cyclops-ansible/roles/CTL-Fed-Security.freeipa-client/tasks/main.yml:4
fatal: [lab-css-fw-01.rogue]: FAILED! => {
    "assertion": "ansible_distribution + '-' + ansible_distribution_major_version in freeipaclient_supported_distributions",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
fatal: [lab-css-fw-02.rogue]: FAILED! => {
    "assertion": "ansible_distribution + '-' + ansible_distribution_major_version in freeipaclient_supported_distributions",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}


This will fix the issue.