### PR TITLE
Updated supported distros in meta/main.yml to include Fedora 27,29

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,8 @@ galaxy_info:
   - name: Fedora
     versions:
     - 24
+    - 27
+    - 29
   - name: Ubuntu
     versions:
     - trusty


### PR DESCRIPTION
The supported distro list was missing Fedora 27 and 29.  Updated