### PR TITLE
Add fedora 33 and 34 to supported distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This role allows to join clients to an ipa domain.
 * Fedora 30
 * Fedora 31
 * Fedora 32
+* Fedora 33
+* Fedora 34
 * Ubuntu Trusty
 * Ubuntu Xenial
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,3 +11,6 @@ freeipaclient_supported_distributions:
   - Fedora-30
   - Fedora-31
   - Fedora-32
+  - Fedora-33
+  - Fedora-34
+  


### PR DESCRIPTION
Update support for Fedora 33 and 34 distributions.  